### PR TITLE
Add test buildouts, fix tests, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 *.pyc
 *.pyo
 *.mo
+.installed.cfg
+.mr.developer.cfg
+buildout.cfg
+bin/
+develop-eggs/
+dist/
+eggs/
+parts/

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,178 @@
+##############################################################################
+#
+# Copyright (c) 2006 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Bootstrap a buildout-based project
+
+Simply run this script in a directory containing a buildout.cfg.
+The script accepts buildout command-line options, so you can
+use the -c option to specify an alternate configuration file.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+from optparse import OptionParser
+
+tmpeggs = tempfile.mkdtemp()
+
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep 
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("-v", "--version", help="use a specific zc.buildout version")
+
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+
+
+options, args = parser.parse_args()
+
+######################################################################
+# load/install setuptools
+
+try:
+    if options.allow_site_packages:
+        import setuptools
+        import pkg_resources
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions 
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'. 
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+cmd = [sys.executable, '-c',
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+requirement = 'zc.buildout'
+version = options.version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        for part in parsed_version:
+            if (part[:1] == '*') and (part not in _final_parts):
+                return False
+        return True
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
+
+ws.add_entry(tmpeggs)
+ws.require(requirement)
+import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
+shutil.rmtree(tmpeggs)

--- a/ftw/usermigration/__init__.py
+++ b/ftw/usermigration/__init__.py
@@ -1,8 +1,7 @@
-from zope.i18nmessageid import MessageFactory
 from Products.CMFCore.permissions import setDefaultRoles
+from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('ftw.usermigration')
 
 setDefaultRoles('ftw.usermigration: Migrate users',
                 ('Manager', 'Site Administrator', ))
-

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -1,18 +1,18 @@
-import transaction
 from Acquisition import aq_inner
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from zope import interface, schema
-from z3c.form import form, field, button
-from z3c.form.interfaces import WidgetActionExecutionError
 from ftw.usermigration import _
 from ftw.usermigration.dashboard import migrate_dashboards
-from ftw.usermigration.localroles import migrate_localroles
 from ftw.usermigration.homefolder import migrate_homefolders
-from ftw.usermigration.users import migrate_users
+from ftw.usermigration.localroles import migrate_localroles
 from ftw.usermigration.properties import migrate_properties
-from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
-from zope.interface import Invalid
+from ftw.usermigration.users import migrate_users
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from z3c.form import form, field, button
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
+from z3c.form.interfaces import WidgetActionExecutionError
+from zope import interface, schema
+from zope.interface import Invalid
+from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+import transaction
 
 
 class IUserMigrationFormSchema(interface.Interface):
@@ -46,8 +46,8 @@ class IUserMigrationFormSchema(interface.Interface):
     mode = schema.Choice(
         title=_(u'label_migration_mode', default='Mode'),
         description=_(u'help_migration_mode', default=u'Choose a migration '
-          'mode. Copy will keep user data of the old user. Delete will just '
-          'remove user data of the old user.'),
+            'mode. Copy will keep user data of the old user. Delete will just '
+            'remove user data of the old user.'),
         vocabulary=SimpleVocabulary([
             SimpleTerm('move', 'move', _(u'Move')),
             SimpleTerm('copy', 'copy', _(u"Copy")),
@@ -72,9 +72,10 @@ class IUserMigrationFormSchema(interface.Interface):
           'modify any data and to see what would have been migrated.'),
     )
 
+
 class UserMigrationForm(form.Form):
     fields = field.Fields(IUserMigrationFormSchema)
-    ignoreContext = True # don't use context to get widget data
+    ignoreContext = True  # don't use context to get widget data
     label = u"Migrate UserIDs"
 
     def __init__(self, context, request):
@@ -100,29 +101,29 @@ class UserMigrationForm(form.Form):
             try:
                 old_userid, new_userid = line.split(':')
             except ValueError:
-                raise WidgetActionExecutionError('user_mapping',
-                    Invalid('Invalid user mapping provided.'))
+                raise WidgetActionExecutionError(
+                    'user_mapping', Invalid('Invalid user mapping provided.'))
             userids[old_userid] = new_userid
 
         if 'users' in data['migrations']:
-            self.results_users = migrate_users(context, userids,
-                mode=data['mode'], replace=data['replace'])
+            self.results_users = migrate_users(
+                context, userids, mode=data['mode'], replace=data['replace'])
 
         if 'properties' in data['migrations']:
-            self.results_properties = migrate_properties(context, userids,
-                mode=data['mode'], replace=data['replace'])
+            self.results_properties = migrate_properties(
+                context, userids, mode=data['mode'], replace=data['replace'])
 
         if 'dashboard' in data['migrations']:
-            self.results_dashboard = migrate_dashboards(context, userids,
-                mode=data['mode'], replace=data['replace'])
+            self.results_dashboard = migrate_dashboards(
+                context, userids, mode=data['mode'], replace=data['replace'])
 
         if 'homefolder' in data['migrations']:
-            self.results_homefolder = migrate_homefolders(context, userids,
-                mode=data['mode'], replace=data['replace'])
+            self.results_homefolder = migrate_homefolders(
+                context, userids, mode=data['mode'], replace=data['replace'])
 
         if 'localroles' in data['migrations']:
-            self.results_localroles = migrate_localroles(context, userids,
-                mode=data['mode'])
+            self.results_localroles = migrate_localroles(
+                context, userids, mode=data['mode'])
 
         if data['dry_run']:
             transaction.abort()

--- a/ftw/usermigration/dashboard.py
+++ b/ftw/usermigration/dashboard.py
@@ -1,5 +1,5 @@
-from plone.portlets.interfaces import IPortletManager
 from plone.portlets.constants import USER_CATEGORY
+from plone.portlets.interfaces import IPortletManager
 from zope.component import queryUtility
 
 

--- a/ftw/usermigration/homefolder.py
+++ b/ftw/usermigration/homefolder.py
@@ -1,5 +1,5 @@
-from Products.CMFCore.utils import getToolByName
 from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
 
 
 def migrate_homefolders(context, mapping, mode='move', replace=False):
@@ -32,13 +32,13 @@ def migrate_homefolders(context, mapping, mode='move', replace=False):
                     continue
 
         # Rename home folder
-        if mode=='move':
+        if mode == 'move':
             container.manage_renameObject(old_home_id, new_home_id)
             new_home = container[new_home_id]
             moved.append((old_userid, new_userid))
 
         # Copy home folder
-        elif mode=='copy':
+        elif mode == 'copy':
             new_ids = container.manage_pasteObjects(
                 cb_copy_data=container.manage_copyObjects(ids=[old_home_id]))
             container.manage_renameObject(new_ids[0]['new_id'], new_home_id)
@@ -46,7 +46,7 @@ def migrate_homefolders(context, mapping, mode='move', replace=False):
             copied.append((old_userid, new_userid))
 
         # Delete home folder
-        elif mode=='delete':
+        elif mode == 'delete':
             container.manage_delObjects(ids=[old_home_id])
             deleted.append((old_userid, None))
 

--- a/ftw/usermigration/localroles.py
+++ b/ftw/usermigration/localroles.py
@@ -5,7 +5,7 @@ def migrate_localroles(context, mapping, mode='move'):
     moved = []
     copied = []
     deleted = []
-    
+
     # Paths needing reindexing of security
     reindex_paths = set()
 
@@ -13,12 +13,12 @@ def migrate_localroles(context, mapping, mode='move'):
         """Determine if an ancestor of the given path is already in
            reindex_paths."""
         path_parts = path.split('/')
-        for i,part in enumerate(path_parts):
-            subpath = '/'.join(path_parts[:i+1])
+        for i, part in enumerate(path_parts):
+            subpath = '/'.join(path_parts[:i + 1])
             if subpath in reindex_paths:
                 return True
         return False
-        
+
     def migrate_and_recurse(context):
         local_roles = context.get_local_roles()
         path = '/'.join(context.getPhysicalPath())
@@ -39,7 +39,7 @@ def migrate_localroles(context, mapping, mode='move'):
                         copied.append((path, old_userid, new_userid))
                     elif mode == 'delete':
                         deleted.append((path, old_userid, None))
-        
+
         for obj in context.objectValues():
             migrate_and_recurse(obj)
 
@@ -48,5 +48,5 @@ def migrate_localroles(context, mapping, mode='move'):
     for path in reindex_paths:
         obj = context.unrestrictedTraverse(path)
         obj.reindexObjectSecurity()
-    
+
     return(dict(moved=moved, copied=copied, deleted=deleted))

--- a/ftw/usermigration/properties.py
+++ b/ftw/usermigration/properties.py
@@ -1,5 +1,5 @@
-from Products.CMFCore.utils import getToolByName
 from copy import deepcopy
+from Products.CMFCore.utils import getToolByName
 
 
 def migrate_properties(context, mapping, mode='move', replace=False):

--- a/ftw/usermigration/tests/test_dashboard.py
+++ b/ftw/usermigration/tests/test_dashboard.py
@@ -1,19 +1,20 @@
-from unittest2 import TestCase
+from ftw.usermigration.dashboard import migrate_dashboards
+from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
+from plone.app.portlets.storage import UserPortletAssignmentMapping
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
-from ftw.usermigration.dashboard import migrate_dashboards
-from Products.CMFCore.utils import getToolByName
 from plone.portlets.constants import USER_CATEGORY
 from plone.portlets.interfaces import IPortletManager
+from Products.CMFCore.utils import getToolByName
+from unittest2 import TestCase
 from zope.component import queryUtility
-from plone.app.portlets.storage import UserPortletAssignmentMapping
 
 
 class DummyPortletAssignment(object):
-    
+
     def __init__(self, name):
         self.name = name
+
     def __repr__(self):
         return self.name
 
@@ -21,8 +22,8 @@ class DummyPortletAssignment(object):
 class TestLocalRoles(TestCase):
 
     layer = USERMIGRATION_INTEGRATION_TESTING
-    
-    def setUp(self):        
+
+    def setUp(self):
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
@@ -40,7 +41,7 @@ class TestLocalRoles(TestCase):
             for user in users:
                 if user in category:
                     del category[user]
-        
+
         # Assign portlets in column 'plone.dashboard2'
         column = queryUtility(IPortletManager, name='plone.dashboard2')
         category = column.get(USER_CATEGORY)
@@ -79,7 +80,6 @@ class TestLocalRoles(TestCase):
         self.assertIn('peter', category3)
         self.assertEqual('peter-col3', category3['peter']['portlet-1'].name)
 
-
         self.assertIn(('plone.dashboard2', 'john', 'peter'), results['moved'])
         self.assertNotIn(('plone.dashboard3', 'john', 'peter'), results['moved'])
         self.assertEqual([], results['copied'])
@@ -93,11 +93,11 @@ class TestLocalRoles(TestCase):
         category2 = column2.get(USER_CATEGORY, None)
         column3 = queryUtility(IPortletManager, name='plone.dashboard3')
         category3 = column3.get(USER_CATEGORY, None)
-        
+
         self.assertIn('peter', category2)
         self.assertNotIn('john', category2)
         self.assertEqual('john-col2', category2['peter']['portlet-1'].name)
-        
+
         self.assertIn('peter', category3)
         self.assertNotIn('john', category3)
         self.assertEqual('john-col3', category3['peter']['portlet-1'].name)

--- a/ftw/usermigration/tests/test_dashboard.py
+++ b/ftw/usermigration/tests/test_dashboard.py
@@ -18,6 +18,9 @@ class DummyPortletAssignment(object):
     def __repr__(self):
         return self.name
 
+    def __of__(self, obj):
+        return self
+
 
 class TestLocalRoles(TestCase):
 

--- a/ftw/usermigration/tests/test_homefolder.py
+++ b/ftw/usermigration/tests/test_homefolder.py
@@ -1,17 +1,17 @@
-from unittest2 import TestCase
+from ftw.usermigration.homefolder import migrate_homefolders
+from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
-from ftw.usermigration.homefolder import migrate_homefolders
 from Products.CMFCore.utils import getToolByName
-
+from unittest2 import TestCase
 import transaction
+
 
 class HomefolderMigrationTest(TestCase):
 
     layer = USERMIGRATION_INTEGRATION_TESTING
-    
-    def setUp(self):        
+
+    def setUp(self):
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
@@ -32,7 +32,7 @@ class HomefolderMigrationTest(TestCase):
         # Create some content
         johns_home = mtool.getHomeFolder('john')
         johns_home.invokeFactory('Folder', 'folder1')
-        
+
         # Objects need a DB connection to be copyable
         transaction.savepoint()
 
@@ -54,7 +54,7 @@ class HomefolderMigrationTest(TestCase):
         portal = self.layer['portal']
         mapping = {'john': 'peter'}
         migrate_homefolders(portal, mapping)
-        
+
         self.assertIn(
             ('peter', ('Owner',)),
             self.folder['peter'].get_local_roles()
@@ -111,7 +111,7 @@ class HomefolderMigrationTest(TestCase):
         mtool = getToolByName(portal, 'portal_membership', None)
         self.assertEquals(None, mtool.getHomeFolder(id='john@domain.net'))
         self.assertNotEquals(None, mtool.getHomeFolder(id='peter@domain.net'))
-        
+
         self.assertIn(('john@domain.net', 'peter@domain.net'), results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])

--- a/ftw/usermigration/tests/test_localroles.py
+++ b/ftw/usermigration/tests/test_localroles.py
@@ -9,8 +9,8 @@ from Products.CMFCore.utils import getToolByName
 class TestLocalRoles(TestCase):
 
     layer = USERMIGRATION_INTEGRATION_TESTING
-    
-    def setUp(self):        
+
+    def setUp(self):
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
@@ -107,7 +107,7 @@ class TestLocalRoles(TestCase):
         portal = self.layer['portal']
         mapping = {'john': 'peter'}
         results = migrate_localroles(portal, mapping, mode='copy')
-        
+
         self.assertIn(('/plone/folder', 'john', 'peter'), results['copied'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['deleted'])
@@ -118,7 +118,7 @@ class TestLocalRoles(TestCase):
         portal = self.layer['portal']
         mapping = {'john': 'peter'}
         results = migrate_localroles(portal, mapping, mode='delete')
-        
+
         self.assertIn(('/plone/folder', 'john', None), results['deleted'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['copied'])

--- a/ftw/usermigration/tests/test_properties.py
+++ b/ftw/usermigration/tests/test_properties.py
@@ -1,9 +1,9 @@
-from unittest2 import TestCase
+from ftw.usermigration.properties import migrate_properties
+from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
-from ftw.usermigration.properties import migrate_properties
 from Products.CMFCore.utils import getToolByName
+from unittest2 import TestCase
 
 
 class TestProperties(TestCase):

--- a/ftw/usermigration/tests/test_users.py
+++ b/ftw/usermigration/tests/test_users.py
@@ -1,9 +1,9 @@
-from unittest2 import TestCase
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
 from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
 from ftw.usermigration.users import migrate_users
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from Products.CMFCore.utils import getToolByName
+from unittest2 import TestCase
 
 
 class TestUsers(TestCase):

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
+
+package-name = ftw.usermigration

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+
+package-name = ftw.usermigration

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+
+package-name = ftw.usermigration


### PR DESCRIPTION
- Added test buildouts for Plone `4.1`, `4.2` and `4.3`
- Added `__of__()` method to `DummyPortletAssignment` to make tests pass again. (Since `Products.PloneHotfix20130618` [PortletAssignments get acquisition wrapped when retrieved from an PortletAssignmentAssignmentMapping](https://github.com/plone/plone.app.portlets/commit/4a28242e4c9900ee0e75a5ba62584af9af97457a))
- Some PEP8 and whitespace cleanups

@buchi @phgross
