### PR TITLE
Rename `user` to `principal` where applicable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 Introduction
 ============
 
-This product allows migrating various user specific data associated with a 
-userid to an other userid. It's especially usefuel if userids have to be
-renamed.
+This product allows migrating various user specific data associated with a
+principal ID (user or group) to an other principal ID. It's especially useful
+if IDs have to be renamed.
 
 Currently the following user data can be migrated:
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,11 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Rename `user` to `principal` where applicable:
+
+  Most of the operations work for groups as well as for users.
+  Therefore the mapping can contain principal IDs, not just
+  user IDs.
 
 
 1.0 (2014-06-16)

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -8,7 +8,7 @@
 <body>
 
 <metal:title fill-slot="content-title">
-    <h1 class="documentFirstHeading">User Migration Results</h1>
+    <h1 class="documentFirstHeading">User / Group Migration Results</h1>
 </metal:title>
 
 <metal:description fill-slot="content-description"></metal:description>
@@ -33,14 +33,14 @@
     </tal:block>
     </tal:users>
 
-    <tal:users repeat="mode python:view.results_properties.keys()">
+    <tal:properties repeat="mode python:view.results_properties.keys()">
     <tal:block define="rows python:view.results_properties[mode]"
                condition="rows">
-    <h2>User Properties <span tal:replace="mode" /></h2>
+    <h2>User / Group Properties <span tal:replace="mode" /></h2>
     <table class="listing">
         <tr>
-            <th>Old UserId</th>
-            <th>New UserId</th>
+            <th>Old ID</th>
+            <th>New ID</th>
         </tr>
         <tr tal:repeat="row rows">
             <td tal:content="python: row[0]" />
@@ -48,7 +48,7 @@
         </tr>
     </table>
     </tal:block>
-    </tal:users>
+    </tal:properties>
 
     <tal:localroles repeat="mode python:view.results_localroles.keys()">
     <tal:block define="rows python:view.results_localroles[mode]"
@@ -57,8 +57,8 @@
     <table class="listing">
         <tr>
             <th>Path</th>
-            <th>Old UserId</th>
-            <th>New UserId</th>
+            <th>Old ID</th>
+            <th>New ID</th>
         </tr>
         <tr tal:repeat="row rows">
             <td tal:content="python: row[0]" />
@@ -69,7 +69,7 @@
     </tal:block>
     </tal:localroles>
 
-    <tal:localroles repeat="mode python:view.results_dashboard.keys()">
+    <tal:dashboards repeat="mode python:view.results_dashboard.keys()">
     <tal:block define="rows python:view.results_dashboard[mode]"
                condition="rows">
     <h2>Dashboards <span tal:replace="mode" /></h2>
@@ -86,9 +86,9 @@
         </tr>
     </table>
     </tal:block>
-    </tal:localroles>
+    </tal:dashboards>
 
-    <tal:localroles repeat="mode python:view.results_homefolder.keys()">
+    <tal:homefolders repeat="mode python:view.results_homefolder.keys()">
     <tal:block define="rows python:view.results_homefolder[mode]"
                condition="rows">
     <h2>Homefolders <span tal:replace="mode" /></h2>
@@ -103,7 +103,7 @@
         </tr>
     </table>
     </tal:block>
-    </tal:localroles>
+    </tal:homefolders>
 
     </metal:content-core>
 </metal:content-core>

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -19,7 +19,8 @@ class IUserMigrationFormSchema(interface.Interface):
 
     user_mapping = schema.List(
         title=_(u'label_user_mapping', default=u'User Mapping'),
-        description=_(u'help_user_mapping', default=u'Provide a pair of old '
+        description=_(u'help_user_mapping',
+                      default=u'Provide a pair of old '
                       'and new userid separated by a colon per line (e.g. '
                       'olduserid:newuserid).'),
         default=[],
@@ -45,9 +46,10 @@ class IUserMigrationFormSchema(interface.Interface):
 
     mode = schema.Choice(
         title=_(u'label_migration_mode', default='Mode'),
-        description=_(u'help_migration_mode', default=u'Choose a migration '
-            'mode. Copy will keep user data of the old user. Delete will just '
-            'remove user data of the old user.'),
+        description=_(u'help_migration_mode',
+                      default=u'Choose a migration '
+                      'mode. Copy will keep user data of the old user. Delete '
+                      'will just remove user data of the old user.'),
         vocabulary=SimpleVocabulary([
             SimpleTerm('move', 'move', _(u'Move')),
             SimpleTerm('copy', 'copy', _(u"Copy")),
@@ -59,17 +61,19 @@ class IUserMigrationFormSchema(interface.Interface):
 
     replace = schema.Bool(
         title=_(u'label_replace', default=u"Replace Existing Data"),
-        description=_(u'help_replace', default=u'Check this option to replace '
-          'existing user data. If unchecked, user data is not migrated when it'
-          ' already exists for a given userid.'),
+        description=_(u'help_replace',
+                      default=u'Check this option to replace existing user '
+                      'data. If unchecked, user data is not migrated when it'
+                      ' already exists for a given userid.'),
         default=False,
     )
 
     dry_run = schema.Bool(
         title=_(u'label_dry_run', default=u'Dry Run'),
         default=False,
-        description=_(u'help_dry_run', default=u'Check this option to not '
-          'modify any data and to see what would have been migrated.'),
+        description=_(u'help_dry_run',
+                      default=u'Check this option to not modify any data and '
+                      'to see what would have been migrated.'),
     )
 
 

--- a/ftw/usermigration/localroles.py
+++ b/ftw/usermigration/localroles.py
@@ -23,22 +23,24 @@ def migrate_localroles(context, mapping, mode='move'):
         local_roles = context.get_local_roles()
         path = '/'.join(context.getPhysicalPath())
         for role in local_roles:
-            for old_userid, new_userid in mapping.items():
-                if role[0] == old_userid:
+            for old_id, new_id in mapping.items():
+                if role[0] == old_id:
                     if mode in ['move', 'copy']:
-                        context.manage_setLocalRoles(new_userid, list(role[1]))
+                        context.manage_setLocalRoles(new_id, list(role[1]))
                         if not is_reindexing_ancestor(path):
                             reindex_paths.add(path)
                     if mode in ['move', 'delete']:
-                        context.manage_delLocalRoles(userids=[old_userid])
+                        # Even though the kw argument is named `userids`,
+                        # these are in fact principal IDs (groups or users)
+                        context.manage_delLocalRoles(userids=[old_id])
                         if not is_reindexing_ancestor(path):
                             reindex_paths.add(path)
                     if mode == 'move':
-                        moved.append((path, old_userid, new_userid))
+                        moved.append((path, old_id, new_id))
                     elif mode == 'copy':
-                        copied.append((path, old_userid, new_userid))
+                        copied.append((path, old_id, new_id))
                     elif mode == 'delete':
-                        deleted.append((path, old_userid, None))
+                        deleted.append((path, old_id, None))
 
         for obj in context.objectValues():
             migrate_and_recurse(obj)

--- a/ftw/usermigration/properties.py
+++ b/ftw/usermigration/properties.py
@@ -3,7 +3,7 @@ from Products.CMFCore.utils import getToolByName
 
 
 def migrate_properties(context, mapping, mode='move', replace=False):
-    """Migrate user properties."""
+    """Migrate user and group properties."""
 
     # Statistics
     moved = []
@@ -13,29 +13,29 @@ def migrate_properties(context, mapping, mode='move', replace=False):
     uf = getToolByName(context, 'acl_users')
     plugin = uf.get('mutable_properties')
 
-    for old_userid, new_userid in mapping.items():
+    for old_id, new_id in mapping.items():
 
-        if old_userid not in plugin._storage:
+        if old_id not in plugin._storage:
             continue
 
-        # Do nothing if new user already has some properties and
+        # Do nothing if new user or group already has some properties and
         # replace is False.
-        if new_userid in plugin._storage and not replace:
+        if new_id in plugin._storage and not replace:
             continue
 
-        data = plugin._storage.get(old_userid)
+        data = plugin._storage.get(old_id)
 
         if mode in ['copy', 'move']:
-            plugin._storage[new_userid] = deepcopy(data)
+            plugin._storage[new_id] = deepcopy(data)
 
         if mode in ['move', 'delete']:
-            plugin.deleteUser(old_userid)
+            plugin.deleteUser(old_id)
 
         if mode == 'move':
-            moved.append((old_userid, new_userid))
+            moved.append((old_id, new_id))
         if mode == 'copy':
-            copied.append((old_userid, new_userid))
+            copied.append((old_id, new_id))
         if mode == 'delete':
-            deleted.append((old_userid, None))
+            deleted.append((old_id, None))
 
     return(dict(moved=moved, copied=copied, deleted=deleted))


### PR DESCRIPTION
Rename occurrences of `user` to `principal` where applicable

Most of the operations work for groups as well as for users.

Therefore the mapping can contain principal IDs, not just user IDs.
So in this change all occurrences of `user` are renamed in places where it could potentially be both.

This is a pure refactoring, no functional changes have been introduced (except changes to some user-visible labels / titles).  

@buchi @phgross @deiferni 
