### PR TITLE
Support for programmatically providing mappings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,42 @@ Usage
 
 Open ``@@user-migration`` in your browser.
 
+Registering principal mappings
+------------------------------
+
+If you would like to provide the principal mapping in a programmatic way
+instead of entering it through-the-web, you can register one or more named
+adapters that implement ``IPrincipalMappingSource``.
+
+Example:
+
+.. code:: python
+
+	class MigrationMapping(object):
+
+	    def __init__(self, portal, request):
+	        self.portal = portal
+	        self.request = request
+
+	    def get_mapping(self):
+	        mapping = {'old_user': 'new_user',
+	                   'old_group': 'new_group'}
+	        return mapping
+
+ZCML:
+
+.. code:: xml
+
+    <adapter
+        factory="my.package.migration.MigrationMapping"
+        provides="ftw.usermigration.interfaces.IPrincipalMappingSource"
+        for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot
+             zope.publisher.interfaces.browser.IBrowserRequest"
+        name="ad-migration-2015"
+    />
+
+This will result in this mapping being selectable as a mapping source with the
+name ``ad-migration-2015`` in the ``@@user-migration`` form.
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Add support for programmatically providing principal mappings
+  by registering an IPrincipalMappingSource named adapter.
+  [lgraf]
+
 - Rename `user` to `principal` where applicable:
 
   Most of the operations work for groups as well as for users.

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -11,7 +11,8 @@ from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.interfaces import WidgetActionExecutionError
 from zope import interface, schema
 from zope.interface import Invalid
-from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 import transaction
 
 

--- a/ftw/usermigration/configure.zcml
+++ b/ftw/usermigration/configure.zcml
@@ -11,5 +11,10 @@
 
     <include package=".browser" />
 
+    <utility
+        provides="zope.schema.interfaces.IVocabularyFactory"
+        factory=".vocabularies.MappingSourcesVocabularyFactory"
+        name="ftw.usermigration.mapping_sources"
+        />
 
 </configure>

--- a/ftw/usermigration/interfaces.py
+++ b/ftw/usermigration/interfaces.py
@@ -1,0 +1,13 @@
+from zope.interface import Interface
+
+
+class IPrincipalMappingSource(Interface):
+
+    def __init__(portal, request):
+        """The adapter adapts portal and request.
+        """
+
+    def get_mapping():
+        """Returns the principal mapping as a dictionary, mapping old IDs (key)
+        to new IDs (value).
+        """

--- a/ftw/usermigration/testing.py
+++ b/ftw/usermigration/testing.py
@@ -1,3 +1,4 @@
+from ftw.builder.testing import BUILDER_LAYER
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -7,7 +8,7 @@ from zope.configuration import xmlconfig
 
 class UserMigrationLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         import z3c.autoinclude

--- a/ftw/usermigration/tests/test_migration_form.py
+++ b/ftw/usermigration/tests/test_migration_form.py
@@ -1,0 +1,162 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.z3cform import erroneous_fields
+from ftw.usermigration.interfaces import IPrincipalMappingSource
+from ftw.usermigration.testing import USERMIGRATION_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from unittest2 import TestCase
+from zope.component import getGlobalSiteManager
+from zope.publisher.interfaces.browser import IBrowserRequest
+import transaction
+
+
+def make_mapping(dct):
+    """Create a mapping string suitable for our ASCIILines widget from a dict
+    """
+    return '\n'.join(':'.join((key, value)) for key, value in dct.items())
+
+
+class DummyMigrationMappingSource(object):
+
+    def __init__(self, portal, request):
+        pass
+
+    def get_mapping(self):
+        return {'old_john': 'new_john'}
+
+
+class TestMigrationForm(TestCase):
+
+    layer = USERMIGRATION_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.uf = getToolByName(self.portal, 'acl_users')
+
+        create(Builder('user').with_userid('old_john'))
+        transaction.commit()
+
+    @browsing
+    def test_form_defaults_to_using_manual_mapping(self, browser):
+        browser.login().visit(view='user-migration')
+
+        mapping = make_mapping({'old_john': 'new_john'})
+        browser.fill(
+            {'Manual Principal Mapping': mapping}).fill(
+            {'Migrations': ['users']}
+        ).submit()
+
+        self.assertEquals(1, len(self.uf.searchUsers(id='new_john')))
+
+    @browsing
+    def test_form_complains_about_invalid_manual_mapping(self, browser):
+        browser.login().visit(view='user-migration')
+
+        browser.fill(
+            {'Manual Principal Mapping': 'a:b:c:d:e:f'}
+        ).submit()
+
+        self.assertIn(
+            ['Invalid principal mapping provided.'],
+            erroneous_fields(browser.forms['form']).values())
+
+    @browsing
+    def test_helpful_message_if_manual_mapping_required(self, browser):
+        browser.login().visit(view='user-migration')
+
+        browser.fill(
+            {'Migrations': ['users']}
+        ).submit()
+
+        self.assertIn(
+            ['Manual mapping is required if "Use manually entered mapping" '
+             'has been selected.'],
+            erroneous_fields(browser.forms['form']).values())
+
+    @browsing
+    def test_dry_run(self, browser):
+        browser.login().visit(view='user-migration')
+
+        db = self.portal._p_jar.db()
+        last_transaction = db.lastTransaction()
+
+        mapping = make_mapping({'old_john': 'new_john'})
+        browser.fill(
+            {'Manual Principal Mapping': mapping}).fill(
+            {'Migrations': ['users', 'properties', 'dashboard',
+                            'homefolder', 'localroles']}).fill(
+            {'Dry Run': True}
+        ).submit()
+
+        self.assertEquals(
+            last_transaction, db.lastTransaction(),
+            'Last transaction in DB should have been the same as before '
+            'running the migration in dry run mode - this means there have '
+            'been changes written to the DB!')
+
+    @browsing
+    def test_can_use_mapping_source_adapters(self, browser):
+        gsm = getGlobalSiteManager()
+        gsm.registerAdapter(
+            DummyMigrationMappingSource, (IPloneSiteRoot, IBrowserRequest),
+            IPrincipalMappingSource, name='some-migration-mapping')
+
+        browser.login().visit(view='user-migration')
+
+        browser.fill(
+            {'Principal Mapping Source': 'some-migration-mapping'}).fill(
+            {'Migrations': ['users']}
+        ).submit()
+
+        self.assertEquals(1, len(self.uf.searchUsers(id='new_john')))
+
+    @browsing
+    def test_form_user_move(self, browser):
+        browser.login().visit(view='user-migration')
+
+        mapping = make_mapping({'old_john': 'new_john',
+                                'old_jack': 'new_jack'})
+        browser.fill(
+            {'Manual Principal Mapping': mapping}).fill(
+            {'Migrations': ['users', 'localroles']}
+        ).submit()
+
+        user = self.uf.searchUsers(id='new_john')[0]
+
+        # New user's userid is correct
+        self.assertEquals('new_john', user['userid'])
+
+        # Login of new user has been set to userid
+        self.assertEquals('new_john', user['login'])
+
+        # Old user is gone
+        self.assertEquals((), self.uf.searchUsers(id='old_john'))
+
+    @browsing
+    def test_form_user_copy(self, browser):
+        browser.login().visit(view='user-migration')
+
+        mapping = make_mapping({'old_john': 'new_john',
+                                'old_jack': 'new_jack'})
+        browser.fill(
+            {'Manual Principal Mapping': mapping}).fill(
+            {'Migrations': ['users', 'localroles']}).fill(
+            {'Mode': 'copy'}
+        ).submit()
+
+        user = self.uf.searchUsers(id='new_john')[0]
+
+        # New user's userid is correct
+        self.assertEquals('new_john', user['userid'])
+
+        # Login of new user has been set to userid
+        self.assertEquals('new_john', user['login'])
+
+        # Old user still exists
+        old_user = self.uf.searchUsers(id='old_john')[0]
+        self.assertEquals('old_john', old_user['userid'])

--- a/ftw/usermigration/vocabularies.py
+++ b/ftw/usermigration/vocabularies.py
@@ -1,0 +1,26 @@
+from ftw.usermigration.interfaces import IPrincipalMappingSource
+from zope.component import getAdapters
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+USE_MANUAL_MAPPING = 'use_manual_mapping'
+
+
+class MappingSourcesVocabularyFactory(object):
+
+    def __call__(self, context):
+        terms = []
+
+        # Always add the 'Use manually entered mapping' option (default)
+        terms.append(SimpleVocabulary.createTerm(
+            USE_MANUAL_MAPPING, USE_MANUAL_MAPPING,
+            'Use manually entered mapping'))
+
+        mapping_sources = getAdapters(
+            (context, context.REQUEST), IPrincipalMappingSource)
+
+        for name, src in mapping_sources:
+            value, token, title = name, name, name
+            terms.append(SimpleVocabulary.createTerm(value, token, title))
+
+        return SimpleVocabulary(terms)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ version = '1.1.dev0'
 
 tests_require = [
     'plone.app.testing',
+    'ftw.builder',
+    'ftw.testbrowser',
     ]
 
 setup(name='ftw.usermigration',


### PR DESCRIPTION
This adds support for programmatically providing principal mappings by registering an `IPrincipalMappingSource` named adapter.

The adapter simply needs to implement a `.get_mapping()` method that returns the mapping from old to new IDs as a dictionary. The name of the adapter is used in the `@@user-migration` form to present the user with the available sources for mappings:

![principal_mapping_source](https://cloud.githubusercontent.com/assets/405124/6719495/492d3e0e-cdbb-11e4-94c2-cdab856b8778.png)

The default is still to provide the mapping by entering it through-the-web in the `Manual principal mapping` field. If an `IPrincipalMappingSource` is selected, the manual mapping will be ignored.

@buchi @phgross @deiferni
