### PR TITLE
Use transaction.doom() for dry runs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Use transaction.doom() for dry runs.
+  This ensures that even an accidental commit() can't result in a DB write.
+
 - Add support for programmatically providing principal mappings
   by registering an IPrincipalMappingSource named adapter.
   [lgraf]

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -139,6 +139,9 @@ class UserMigrationForm(form.Form):
             self.status = self.formErrorsMessage
             return
 
+        if data['dry_run']:
+            transaction.doom()
+
         if data['mapping_source'] == USE_MANUAL_MAPPING:
             # Parse mapping from form field
             principal_mapping = self._get_manual_mapping(data)
@@ -172,9 +175,6 @@ class UserMigrationForm(form.Form):
         if 'localroles' in data['migrations']:
             self.results_localroles = migrate_localroles(
                 context, principal_mapping, mode=data['mode'])
-
-        if data['dry_run']:
-            transaction.abort()
 
         self.result_template = ViewPageTemplateFile('migration.pt')
 


### PR DESCRIPTION
This ensures that even an accidental `commit()` during a dry run can't result in a DB write.
See [`transaction/docs/doom.rst`](https://raw.githubusercontent.com/zopefoundation/transaction/master/docs/doom.rst)

This is particularly important for the upcoming pre- and post-migration adapters that allow other packages to register code that is run in addition to the migrations done in `ftw.usermigration`. If such code were to try and `commit()` the transaction, dooming the transaction in advance will prevent such a `commit()` from being successful.

@buchi @phgross @deiferni 
