### PR TITLE
Make sure `Migrations` field always uses the CheckBoxFieldWidget.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Make sure `Migrations` field always uses the CheckBoxFieldWidget.
+  [lgraf]
+
 - Use transaction.doom() for dry runs.
   This ensures that even an accidental commit() can't result in a DB write.
 

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -183,9 +183,9 @@ class UserMigrationForm(form.Form):
         self.request.response.redirect(self.context.absolute_url())
 
     def updateWidgets(self):
+        self.fields['migrations'].widgetFactory = CheckBoxFieldWidget
         super(UserMigrationForm, self).updateWidgets()
         self.widgets['manual_mapping'].rows = 15
-        self.fields['migrations'].widgetFactory = CheckBoxFieldWidget
 
     def render(self):
         self.request.set('disable_border', True)


### PR DESCRIPTION
The `widgetFactory` must be set on the field before the super call to `updateWidgets()` in oder to always have effect.

@phgross 
