### PR TITLE
Add support for pre- and post-migration hooks.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,61 @@ ZCML:
 This will result in this mapping being selectable as a mapping source with the
 name ``ad-migration-2015`` in the ``@@user-migration`` form.
 
+Registering pre- and post-migration hooks
+-----------------------------------------
+
+If you want to provide your own code that runs before or after any of the
+built-in migration types in ``ftw.usermigration``, you can do so by registering
+hooks that implement the ``IPreMigrationHook`` or ``IPostMigrationHook`` interface.
+
+Example:
+
+.. code:: python
+
+  class ExamplePreMigrationHook(object):
+
+      def __init__(self, portal, request):
+          self.portal = portal
+          self.request = request
+
+      def execute(self, principal_mapping, mode):
+          # ...
+          # your code here
+          # ...
+          results = {
+              'Step 1': {
+                  'moved': [('/foo', 'old', 'new')],
+                  'copied': [],
+                  'deleted': []},
+              'Step 2': {
+                  'moved': [('/bar', 'old', 'new')],
+                  'copied': [],
+                  'deleted': []},
+          }
+          return results
+
+A hook adapter's ``execute()`` method receives the ``principal_mapping`` and
+``mode`` as arguments.
+
+Its results are expected to be a dict of dicts: The outer
+dictionary allows for a hook to group several steps it executes and
+report their results separately. The inner dictionary follows the same
+structure as the results of the built-in migrations.
+
+
+ZCML:
+
+.. code:: xml
+
+    <adapter
+        factory=".migrations.ExamplePreMigrationHook"
+        provides="ftw.usermigration.interfaces.IPreMigrationHook"
+        for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot
+             zope.publisher.interfaces.browser.IBrowserRequest"
+        name="example-pre-migration-hook"
+    />
+
+
 Links
 =====
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Add support for pre- and post-migration hooks.
+  [lgraf]
+
 - Make sure `Migrations` field always uses the CheckBoxFieldWidget.
   [lgraf]
 

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -16,6 +16,37 @@
 <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core">
 
+
+    <tal:pre-migration-hooks define="results_pre_migration view/results_pre_migration"
+                             repeat="hook_name python:results_pre_migration.keys()"
+                             condition="view/results_pre_migration">
+    <h2>Pre-Migration Hooks</h2>
+    <h3 tal:content="hook_name" />
+    <tal:hook_results define="hook_results python:results_pre_migration[hook_name]"
+                      repeat="step_name python:hook_results.keys()">
+    <tal:step_results define="step_results python:hook_results[step_name]"
+                      repeat="mode python:step_results.keys()">
+    <tal:block define="rows python:hook_results[step_name][mode]"
+               condition="rows">
+    <h4 tal:content="string: ${hook_name}: ${step_name} ${mode}" />
+    <table class="listing pre-migration-hook">
+        <tr>
+            <th>Object</th>
+            <th>Old ID</th>
+            <th>New ID</th>
+        </tr>
+        <tr tal:repeat="row rows">
+            <td tal:content="python: row[0]" />
+            <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
+        </tr>
+    </table>
+    </tal:block>
+    </tal:step_results>
+    </tal:hook_results>
+    </tal:pre-migration-hooks>
+
+
     <tal:users repeat="mode python:view.results_users.keys()">
     <tal:block define="rows python:view.results_users[mode]"
                condition="rows">
@@ -33,6 +64,7 @@
     </tal:block>
     </tal:users>
 
+
     <tal:properties repeat="mode python:view.results_properties.keys()">
     <tal:block define="rows python:view.results_properties[mode]"
                condition="rows">
@@ -49,6 +81,7 @@
     </table>
     </tal:block>
     </tal:properties>
+
 
     <tal:localroles repeat="mode python:view.results_localroles.keys()">
     <tal:block define="rows python:view.results_localroles[mode]"
@@ -69,6 +102,7 @@
     </tal:block>
     </tal:localroles>
 
+
     <tal:dashboards repeat="mode python:view.results_dashboard.keys()">
     <tal:block define="rows python:view.results_dashboard[mode]"
                condition="rows">
@@ -88,6 +122,7 @@
     </tal:block>
     </tal:dashboards>
 
+
     <tal:homefolders repeat="mode python:view.results_homefolder.keys()">
     <tal:block define="rows python:view.results_homefolder[mode]"
                condition="rows">
@@ -104,6 +139,37 @@
     </table>
     </tal:block>
     </tal:homefolders>
+
+
+    <tal:post-migration-hooks define="results_post_migration view/results_post_migration"
+                             repeat="hook_name python:results_post_migration.keys()"
+                             condition="view/results_post_migration">
+    <h2>Post-Migration Hooks</h2>
+    <h3 tal:content="hook_name" />
+    <tal:hook_results define="hook_results python:results_post_migration[hook_name]"
+                      repeat="step_name python:hook_results.keys()">
+    <tal:step_results define="step_results python:hook_results[step_name]"
+                      repeat="mode python:step_results.keys()">
+    <tal:block define="rows python:hook_results[step_name][mode]"
+               condition="rows">
+    <h4 tal:content="string: ${hook_name}: ${step_name} ${mode}" />
+    <table class="listing post-migration-hook">
+        <tr>
+            <th>Object</th>
+            <th>Old ID</th>
+            <th>New ID</th>
+        </tr>
+        <tr tal:repeat="row rows">
+            <td tal:content="python: row[0]" />
+            <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
+        </tr>
+    </table>
+    </tal:block>
+    </tal:step_results>
+    </tal:hook_results>
+    </tal:post-migration-hooks>
+
 
     </metal:content-core>
 </metal:content-core>

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -140,10 +140,10 @@ class UserMigrationForm(form.Form):
         manual_mapping = formdata['manual_mapping']
 
         if manual_mapping is None:
-                raise WidgetActionExecutionError(
-                    'manual_mapping',
-                    Invalid('Manual mapping is required if "Use manually '
-                            'entered mapping" has been selected.'))
+            raise WidgetActionExecutionError(
+                'manual_mapping',
+                Invalid('Manual mapping is required if "Use manually '
+                        'entered mapping" has been selected.'))
 
         principal_mapping = {}
         for line in manual_mapping:

--- a/ftw/usermigration/configure.zcml
+++ b/ftw/usermigration/configure.zcml
@@ -17,4 +17,16 @@
         name="ftw.usermigration.mapping_sources"
         />
 
+    <utility
+        provides="zope.schema.interfaces.IVocabularyFactory"
+        factory=".vocabularies.PreMigrationHooksVocabularyFactory"
+        name="ftw.usermigration.pre_migration_hooks"
+        />
+
+    <utility
+        provides="zope.schema.interfaces.IVocabularyFactory"
+        factory=".vocabularies.PostMigrationHooksVocabularyFactory"
+        name="ftw.usermigration.post_migration_hooks"
+        />
+
 </configure>

--- a/ftw/usermigration/interfaces.py
+++ b/ftw/usermigration/interfaces.py
@@ -11,3 +11,25 @@ class IPrincipalMappingSource(Interface):
         """Returns the principal mapping as a dictionary, mapping old IDs (key)
         to new IDs (value).
         """
+
+
+class IPreMigrationHook(Interface):
+
+    def __init__(portal, request):
+        """The adapter adapts portal and request.
+        """
+
+    def execute(principal_mapping, mode):
+        """Runs the pre-migration hook. Returns a dict of results.
+        """
+
+
+class IPostMigrationHook(Interface):
+
+    def __init__(portal, request):
+        """The adapter adapts portal and request.
+        """
+
+    def execute(principal_mapping, mode):
+        """Runs the post-migration hook. Returns a dict of results.
+        """

--- a/ftw/usermigration/testing.py
+++ b/ftw/usermigration/testing.py
@@ -1,4 +1,6 @@
 from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -30,5 +32,6 @@ USERMIGRATION_INTEGRATION_TESTING = IntegrationTesting(
 
 USERMIGRATION_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(USERMIGRATION_FIXTURE,
-           COMPONENT_REGISTRY_ISOLATION),
+           COMPONENT_REGISTRY_ISOLATION,
+           set_builder_session_factory(functional_session_factory)),
     name="ftw.usermigration:functional")

--- a/ftw/usermigration/testing.py
+++ b/ftw/usermigration/testing.py
@@ -1,14 +1,14 @@
 from ftw.builder.testing import BUILDER_LAYER
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from zope.configuration import xmlconfig
 
 
 class UserMigrationLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (BUILDER_LAYER, COMPONENT_REGISTRY_ISOLATION)
 
     def setUpZope(self, app, configurationContext):
         import z3c.autoinclude
@@ -22,7 +22,13 @@ class UserMigrationLayer(PloneSandboxLayer):
 
 
 USERMIGRATION_FIXTURE = UserMigrationLayer()
+
 USERMIGRATION_INTEGRATION_TESTING = IntegrationTesting(
-    bases=(USERMIGRATION_FIXTURE, ), name="ftw.usermigration:integration")
+    bases=(USERMIGRATION_FIXTURE,
+           COMPONENT_REGISTRY_ISOLATION),
+    name="ftw.usermigration:integration")
+
 USERMIGRATION_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(USERMIGRATION_FIXTURE, ), name="ftw.usermigration:functional")
+    bases=(USERMIGRATION_FIXTURE,
+           COMPONENT_REGISTRY_ISOLATION),
+    name="ftw.usermigration:functional")

--- a/ftw/usermigration/tests/test_migration_form.py
+++ b/ftw/usermigration/tests/test_migration_form.py
@@ -68,8 +68,8 @@ class TestMigrationForm(TestCase):
 
         mapping = make_mapping({'old_john': 'new_john'})
         browser.fill(
-            {'Manual Principal Mapping': mapping}).fill(
-            {'Migrations': ['users']}
+            {'Manual Principal Mapping': mapping,
+             'Migrations': ['users']}
         ).submit()
 
         self.assertEquals(1, len(self.uf.searchUsers(id='new_john')))
@@ -108,10 +108,10 @@ class TestMigrationForm(TestCase):
 
         mapping = make_mapping({'old_john': 'new_john'})
         browser.fill(
-            {'Manual Principal Mapping': mapping}).fill(
-            {'Migrations': ['users', 'properties', 'dashboard',
-                            'homefolder', 'localroles']}).fill(
-            {'Dry Run': True}
+            {'Manual Principal Mapping': mapping,
+             'Migrations': ['users', 'properties', 'dashboard',
+                            'homefolder', 'localroles'],
+             'Dry Run': True}
         ).submit()
 
         self.assertEquals(
@@ -130,8 +130,8 @@ class TestMigrationForm(TestCase):
         browser.login().visit(view='user-migration')
 
         browser.fill(
-            {'Principal Mapping Source': 'some-migration-mapping'}).fill(
-            {'Migrations': ['users']}
+            {'Principal Mapping Source': 'some-migration-mapping',
+             'Migrations': ['users']}
         ).submit()
 
         self.assertEquals(1, len(self.uf.searchUsers(id='new_john')))
@@ -182,8 +182,8 @@ class TestMigrationForm(TestCase):
         mapping = make_mapping({'old_john': 'new_john',
                                 'old_jack': 'new_jack'})
         browser.fill(
-            {'Manual Principal Mapping': mapping}).fill(
-            {'Migrations': ['users', 'localroles']}
+            {'Manual Principal Mapping': mapping,
+             'Migrations': ['users', 'localroles']}
         ).submit()
 
         user = self.uf.searchUsers(id='new_john')[0]
@@ -204,9 +204,9 @@ class TestMigrationForm(TestCase):
         mapping = make_mapping({'old_john': 'new_john',
                                 'old_jack': 'new_jack'})
         browser.fill(
-            {'Manual Principal Mapping': mapping}).fill(
-            {'Migrations': ['users', 'localroles']}).fill(
-            {'Mode': 'copy'}
+            {'Manual Principal Mapping': mapping,
+             'Migrations': ['users', 'localroles'],
+             'Mode': 'copy'}
         ).submit()
 
         user = self.uf.searchUsers(id='new_john')[0]

--- a/ftw/usermigration/tests/test_migration_form.py
+++ b/ftw/usermigration/tests/test_migration_form.py
@@ -61,7 +61,6 @@ class TestMigrationForm(TestCase):
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
         create(Builder('user').with_userid('old_john'))
-        transaction.commit()
 
     @browsing
     def test_form_defaults_to_using_manual_mapping(self, browser):

--- a/ftw/usermigration/vocabularies.py
+++ b/ftw/usermigration/vocabularies.py
@@ -1,3 +1,5 @@
+from ftw.usermigration.interfaces import IPostMigrationHook
+from ftw.usermigration.interfaces import IPreMigrationHook
 from ftw.usermigration.interfaces import IPrincipalMappingSource
 from zope.component import getAdapters
 from zope.schema.vocabulary import SimpleVocabulary
@@ -20,6 +22,36 @@ class MappingSourcesVocabularyFactory(object):
             (context, context.REQUEST), IPrincipalMappingSource)
 
         for name, src in mapping_sources:
+            value, token, title = name, name, name
+            terms.append(SimpleVocabulary.createTerm(value, token, title))
+
+        return SimpleVocabulary(terms)
+
+
+class PreMigrationHooksVocabularyFactory(object):
+
+    def __call__(self, context):
+        terms = []
+
+        hooks = getAdapters(
+            (context, context.REQUEST), IPreMigrationHook)
+
+        for name, hook in hooks:
+            value, token, title = name, name, name
+            terms.append(SimpleVocabulary.createTerm(value, token, title))
+
+        return SimpleVocabulary(terms)
+
+
+class PostMigrationHooksVocabularyFactory(object):
+
+    def __call__(self, context):
+        terms = []
+
+        hooks = getAdapters(
+            (context, context.REQUEST), IPostMigrationHook)
+
+        for name, hook in hooks:
             value, token, title = name, name, name
             terms.append(SimpleVocabulary.createTerm(value, token, title))
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ version = '1.1.dev0'
 
 tests_require = [
     'plone.app.testing',
+    'ftw.testing',
     'ftw.builder',
     'ftw.testbrowser',
     ]


### PR DESCRIPTION
This change adds support for registering hooks to be run before and after the built-in migration types in `ftw.usermigration`.

The hooks can be registered by providing named adapters for the `IPreMigrationHook` and/or `IPostMigrationHook` interfaces, and the adapter names are used to display and select the available hooks in the `@@user-migration` form:

![migration_hooks](https://cloud.githubusercontent.com/assets/405124/6786596/aceef204-d18d-11e4-967e-c873e24c5218.png)

The hooks report their results as a dict of dicts (see README), and the results are displayed similar to the results for the built-in migration types, grouped by hook and step:

![migration_hooks_results](https://cloud.githubusercontent.com/assets/405124/6786620/ce936e80-d18d-11e4-8ee7-f063e4513f36.png)

@buchi @phgross @deiferni 
