### PR TITLE
Add migration for global roles (portal_role_manager).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Add migration for global roles (portal_role_manager).
+  [lgraf]
+
 - Add support for pre- and post-migration hooks.
   [lgraf]
 

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -103,6 +103,26 @@
     </tal:localroles>
 
 
+    <tal:globalroles repeat="mode python:view.results_globalroles.keys()">
+    <tal:block define="rows python:view.results_globalroles[mode]"
+               condition="rows">
+    <h2>Global roles <span tal:replace="mode" /></h2>
+    <table class="listing">
+        <tr>
+            <th>Role</th>
+            <th>Old ID</th>
+            <th>New ID</th>
+        </tr>
+        <tr tal:repeat="row rows">
+            <td tal:content="python: row[0]" />
+            <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
+        </tr>
+    </table>
+    </tal:block>
+    </tal:globalroles>
+
+
     <tal:dashboards repeat="mode python:view.results_dashboard.keys()">
     <tal:block define="rows python:view.results_dashboard[mode]"
                condition="rows">

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner
 from ftw.usermigration import _
 from ftw.usermigration.dashboard import migrate_dashboards
+from ftw.usermigration.globalroles import migrate_globalroles
 from ftw.usermigration.homefolder import migrate_homefolders
 from ftw.usermigration.interfaces import IPostMigrationHook
 from ftw.usermigration.interfaces import IPreMigrationHook
@@ -66,6 +67,7 @@ class IUserMigrationFormSchema(interface.Interface):
             vocabulary=SimpleVocabulary([
                 SimpleTerm('users', 'users', _(u'Users')),
                 SimpleTerm('localroles', 'localroles', _(u'Local Roles')),
+                SimpleTerm('globalroles', 'globalroles', _(u'Global Roles')),
                 SimpleTerm('dashboard', 'dashboard', _(u"Dashboard")),
                 SimpleTerm('homefolder', 'homefolder', _(u"Home Folder")),
                 SimpleTerm('properties', 'properties', _(u"User Properties")),
@@ -130,6 +132,7 @@ class UserMigrationForm(form.Form):
         self.result_template = None
         self.results_pre_migration = {}
         self.results_localroles = {}
+        self.results_globalroles = {}
         self.results_dashboard = {}
         self.results_homefolder = {}
         self.results_users = {}
@@ -213,6 +216,10 @@ class UserMigrationForm(form.Form):
 
         if 'localroles' in data['migrations']:
             self.results_localroles = migrate_localroles(
+                context, principal_mapping, mode=data['mode'])
+
+        if 'globalroles' in data['migrations']:
+            self.results_globalroles = migrate_globalroles(
                 context, principal_mapping, mode=data['mode'])
 
         post_migration_hooks = self._get_hooks(

--- a/ftw/usermigration/globalroles.py
+++ b/ftw/usermigration/globalroles.py
@@ -1,0 +1,34 @@
+from operator import itemgetter
+from Products.CMFCore.utils import getToolByName
+
+
+def migrate_globalroles(context, mapping, mode='move'):
+    """Migrate global roles in portal_role_manager."""
+
+    # Statistics
+    moved = []
+
+    if mode != 'move':
+        raise NotImplementedError(
+            "Global roles migration only supports 'move' mode as of yet")
+
+    acl_users = getToolByName(context, 'acl_users')
+    role_manager = acl_users.portal_role_manager
+
+    for role_id in role_manager.listRoleIds():
+        assigned_principals = role_manager.listAssignedPrincipals(role_id)
+        assigned_principal_ids = map(itemgetter(0), assigned_principals)
+
+        for old_principal_id in assigned_principal_ids:
+            if old_principal_id in mapping:
+                new_principal_id = mapping[old_principal_id]
+
+                if new_principal_id in assigned_principal_ids:
+                    # Only assign roles the new user doesn't already have
+                    continue
+
+                role_manager.assignRoleToPrincipal(role_id, new_principal_id)
+                role_manager.removeRoleFromPrincipal(role_id, old_principal_id)
+                moved.append((role_id, old_principal_id, new_principal_id))
+
+    return(dict(moved=moved, copied=[], deleted=[]))

--- a/ftw/usermigration/tests/test_globalroles.py
+++ b/ftw/usermigration/tests/test_globalroles.py
@@ -1,0 +1,92 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.usermigration.globalroles import migrate_globalroles
+from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
+from Products.CMFCore.utils import getToolByName
+from unittest2 import TestCase
+
+
+class TestGlobalRoles(TestCase):
+
+    layer = USERMIGRATION_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+        self.acl_users = getToolByName(self.portal, 'acl_users')
+        self.role_manager = self.acl_users.portal_role_manager
+
+        self.old_user = create(Builder('user').with_userid('old.user'))
+        self.new_user = create(Builder('user').with_userid('new.user'))
+
+        self.role_manager.assignRoleToPrincipal(
+            'Site Administrator', 'old.user')
+
+        self.old_group = create(Builder('group').with_groupid('old.group'))
+        self.new_group = create(Builder('group').with_groupid('new.group'))
+
+        self.role_manager.assignRoleToPrincipal(
+            'Reviewer', 'old.group')
+
+    def test_migrating_global_roles_for_users(self):
+        # old.user had the Site Administrator role according to our setup
+        self.assertIn(
+            ('old.user', 'old.user'),
+            self.role_manager.listAssignedPrincipals('Site Administrator'))
+
+        # New user doesn't yet have that role
+        self.assertNotIn(
+            ('new.user', 'new.user'),
+            self.role_manager.listAssignedPrincipals('Site Administrator'))
+
+        mapping = {'old.user': 'new.user'}
+        migrate_globalroles(self.portal, mapping, mode='move')
+
+        # After the migration he does
+        self.assertIn(
+            ('new.user', 'new.user'),
+            self.role_manager.listAssignedPrincipals('Site Administrator'))
+
+        # And old.user doesn't any more
+        self.assertNotIn(
+            ('old.user', 'old.user'),
+            self.role_manager.listAssignedPrincipals('Site Administrator'))
+
+    def test_migrating_global_roles_for_groups(self):
+        # old.group had the Reviewer role according to our setup
+        self.assertIn(
+            ('old.group', 'old.group'),
+            self.role_manager.listAssignedPrincipals('Reviewer'))
+
+        # New group doesn't yet have that role
+        self.assertNotIn(
+            ('new.group', 'new.group'),
+            self.role_manager.listAssignedPrincipals('Reviewer'))
+
+        mapping = {'old.group': 'new.group'}
+        migrate_globalroles(self.portal, mapping, mode='move')
+
+        # After the migration it does
+        self.assertIn(
+            ('new.group', 'new.group'),
+            self.role_manager.listAssignedPrincipals('Reviewer'))
+
+        # And old.group doesn't any more
+        self.assertNotIn(
+            ('old.group', 'old.group'),
+            self.role_manager.listAssignedPrincipals('Reviewer'))
+
+    def test_migrating_global_roles_returns_correct_results(self):
+        mapping = {'old.user': 'new.user'}
+        results = migrate_globalroles(self.portal, mapping, mode='move')
+
+        self.assertIn(('Site Administrator', 'old.user', 'new.user'),
+                      results['moved'])
+
+    def test_modes_other_than_move_raise_exception(self):
+        mapping = {'old.user': 'new.user'}
+        with self.assertRaises(NotImplementedError):
+            migrate_globalroles(self.portal, mapping, mode='copy')
+
+        with self.assertRaises(NotImplementedError):
+            migrate_globalroles(self.portal, mapping, mode='delete')


### PR DESCRIPTION
This change adds a migration type "Global roles" that migrates global role assignments done through `portal_role_manager`.

![migrations_global_roles](https://cloud.githubusercontent.com/assets/405124/6805997/6cc7a590-d246-11e4-817e-945b2c8fd73b.png)

Results are displayed as `role_id, old_principal_id, new_principal_id`:

![migrations_global_roles_results](https://cloud.githubusercontent.com/assets/405124/6806012/8ca346bc-d246-11e4-9e15-d27f0d78c3d9.png)

Currently, this migration type only supports the `'move'` mode, and raises if any other mode is attempted. It doesn't check whether the new principal exists or not, since the `portal_role_manager` tool handles that case quite well.

@buchi @deiferni @phgross 
