### PR TITLE
Add optional logging of detailed report to logfile

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Add logging of detailed migration results to logfile.
+- Add logging of detailed migration results to logfile (optional).
   [lgraf]
 
 - Add migration for global roles (portal_role_manager).

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Add logging of detailed migration results to logfile.
+  [lgraf]
+
 - Add migration for global roles (portal_role_manager).
   [lgraf]
 

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -47,8 +47,8 @@
     </tal:pre-migration-hooks>
 
 
-    <tal:users repeat="mode python:view.results_users.keys()">
-    <tal:block define="rows python:view.results_users[mode]"
+    <tal:users repeat="mode python:view.results['users'].keys()">
+    <tal:block define="rows python:view.results['users'][mode]"
                condition="rows">
     <h2>Users <span tal:replace="mode" /></h2>
     <table class="listing">
@@ -65,8 +65,8 @@
     </tal:users>
 
 
-    <tal:properties repeat="mode python:view.results_properties.keys()">
-    <tal:block define="rows python:view.results_properties[mode]"
+    <tal:properties repeat="mode python:view.results['properties'].keys()">
+    <tal:block define="rows python:view.results['properties'][mode]"
                condition="rows">
     <h2>User / Group Properties <span tal:replace="mode" /></h2>
     <table class="listing">
@@ -83,8 +83,8 @@
     </tal:properties>
 
 
-    <tal:localroles repeat="mode python:view.results_localroles.keys()">
-    <tal:block define="rows python:view.results_localroles[mode]"
+    <tal:localroles repeat="mode python:view.results['localroles'].keys()">
+    <tal:block define="rows python:view.results['localroles'][mode]"
                condition="rows">
     <h2>Local roles <span tal:replace="mode" /></h2>
     <table class="listing">
@@ -103,8 +103,8 @@
     </tal:localroles>
 
 
-    <tal:globalroles repeat="mode python:view.results_globalroles.keys()">
-    <tal:block define="rows python:view.results_globalroles[mode]"
+    <tal:globalroles repeat="mode python:view.results['globalroles'].keys()">
+    <tal:block define="rows python:view.results['globalroles'][mode]"
                condition="rows">
     <h2>Global roles <span tal:replace="mode" /></h2>
     <table class="listing">
@@ -123,8 +123,8 @@
     </tal:globalroles>
 
 
-    <tal:dashboards repeat="mode python:view.results_dashboard.keys()">
-    <tal:block define="rows python:view.results_dashboard[mode]"
+    <tal:dashboards repeat="mode python:view.results['dashboard'].keys()">
+    <tal:block define="rows python:view.results['dashboard'][mode]"
                condition="rows">
     <h2>Dashboards <span tal:replace="mode" /></h2>
     <table class="listing">
@@ -143,8 +143,8 @@
     </tal:dashboards>
 
 
-    <tal:homefolders repeat="mode python:view.results_homefolder.keys()">
-    <tal:block define="rows python:view.results_homefolder[mode]"
+    <tal:homefolders repeat="mode python:view.results['homefolder'].keys()">
+    <tal:block define="rows python:view.results['homefolder'][mode]"
                condition="rows">
     <h2>Homefolders <span tal:replace="mode" /></h2>
     <table class="listing">

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -57,8 +57,8 @@
             <th>New UserId</th>
         </tr>
         <tr tal:repeat="row rows">
-            <td tal:content="python: row[0]" />
             <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
         </tr>
     </table>
     </tal:block>
@@ -75,8 +75,8 @@
             <th>New ID</th>
         </tr>
         <tr tal:repeat="row rows">
-            <td tal:content="python: row[0]" />
             <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
         </tr>
     </table>
     </tal:block>
@@ -153,8 +153,8 @@
             <th>New UserId</th>
         </tr>
         <tr tal:repeat="row rows">
-            <td tal:content="python: row[0]" />
             <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
         </tr>
     </table>
     </tal:block>

--- a/ftw/usermigration/globalroles.py
+++ b/ftw/usermigration/globalroles.py
@@ -2,7 +2,7 @@ from operator import itemgetter
 from Products.CMFCore.utils import getToolByName
 
 
-def migrate_globalroles(context, mapping, mode='move'):
+def migrate_globalroles(context, mapping, mode='move', replace=False):
     """Migrate global roles in portal_role_manager."""
 
     # Statistics
@@ -11,6 +11,10 @@ def migrate_globalroles(context, mapping, mode='move'):
     if mode != 'move':
         raise NotImplementedError(
             "Global roles migration only supports 'move' mode as of yet")
+
+    if replace:
+        raise NotImplementedError(
+            "Global roles migration only supports 'replace=False' as of yet")
 
     acl_users = getToolByName(context, 'acl_users')
     role_manager = acl_users.portal_role_manager

--- a/ftw/usermigration/homefolder.py
+++ b/ftw/usermigration/homefolder.py
@@ -35,7 +35,7 @@ def migrate_homefolders(context, mapping, mode='move', replace=False):
         if mode == 'move':
             container.manage_renameObject(old_home_id, new_home_id)
             new_home = container[new_home_id]
-            moved.append((old_userid, new_userid))
+            moved.append(('homefolder', old_userid, new_userid))
 
         # Copy home folder
         elif mode == 'copy':
@@ -43,12 +43,12 @@ def migrate_homefolders(context, mapping, mode='move', replace=False):
                 cb_copy_data=container.manage_copyObjects(ids=[old_home_id]))
             container.manage_renameObject(new_ids[0]['new_id'], new_home_id)
             new_home = container[new_home_id]
-            copied.append((old_userid, new_userid))
+            copied.append(('homefolder', old_userid, new_userid))
 
         # Delete home folder
         elif mode == 'delete':
             container.manage_delObjects(ids=[old_home_id])
-            deleted.append((old_userid, None))
+            deleted.append(('homefolder', old_userid, None))
 
         # Assing local roles
         if new_home is not None:

--- a/ftw/usermigration/localroles.py
+++ b/ftw/usermigration/localroles.py
@@ -1,4 +1,4 @@
-def migrate_localroles(context, mapping, mode='move'):
+def migrate_localroles(context, mapping, mode='move', replace=False):
     """Recursively migrate local roles on the given context."""
 
     # Statistics
@@ -8,6 +8,10 @@ def migrate_localroles(context, mapping, mode='move'):
 
     # Paths needing reindexing of security
     reindex_paths = set()
+
+    if replace:
+        raise NotImplementedError(
+            "Local roles migration only supports 'replace=False' as of yet")
 
     def is_reindexing_ancestor(path):
         """Determine if an ancestor of the given path is already in

--- a/ftw/usermigration/properties.py
+++ b/ftw/usermigration/properties.py
@@ -32,10 +32,10 @@ def migrate_properties(context, mapping, mode='move', replace=False):
             plugin.deleteUser(old_id)
 
         if mode == 'move':
-            moved.append((old_id, new_id))
+            moved.append(('mutable_properties', old_id, new_id))
         if mode == 'copy':
-            copied.append((old_id, new_id))
+            copied.append(('mutable_properties', old_id, new_id))
         if mode == 'delete':
-            deleted.append((old_id, None))
+            deleted.append(('mutable_properties', old_id, None))
 
     return(dict(moved=moved, copied=copied, deleted=deleted))

--- a/ftw/usermigration/tests/test_homefolder.py
+++ b/ftw/usermigration/tests/test_homefolder.py
@@ -46,7 +46,7 @@ class HomefolderMigrationTest(TestCase):
         self.assertNotIn('john', members_folder.objectIds())
         self.assertIn('peter', members_folder.objectIds())
 
-        self.assertIn(('john', 'peter'), results['moved'])
+        self.assertIn(('homefolder', 'john', 'peter'), results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
 
@@ -87,7 +87,7 @@ class HomefolderMigrationTest(TestCase):
         self.assertIn('john', self.folder.objectIds())
         self.assertIn('peter', self.folder.objectIds())
 
-        self.assertIn(('john', 'peter'), results['copied'])
+        self.assertIn(('homefolder', 'john', 'peter'), results['copied'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['deleted'])
 
@@ -99,7 +99,7 @@ class HomefolderMigrationTest(TestCase):
         self.assertNotIn('john', self.folder.objectIds())
         self.assertNotIn('peter', self.folder.objectIds())
 
-        self.assertIn(('john', None), results['deleted'])
+        self.assertIn(('homefolder', 'john', None), results['deleted'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['copied'])
 
@@ -112,6 +112,7 @@ class HomefolderMigrationTest(TestCase):
         self.assertEquals(None, mtool.getHomeFolder(id='john@domain.net'))
         self.assertNotEquals(None, mtool.getHomeFolder(id='peter@domain.net'))
 
-        self.assertIn(('john@domain.net', 'peter@domain.net'), results['moved'])
+        self.assertIn(('homefolder', 'john@domain.net', 'peter@domain.net'),
+                      results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])

--- a/ftw/usermigration/tests/test_properties.py
+++ b/ftw/usermigration/tests/test_properties.py
@@ -28,7 +28,8 @@ class TestProperties(TestCase):
         mapping = {'john': 'peter'}
         results = migrate_properties(portal, mapping)
 
-        self.assertIn(('john', 'peter'), results['moved'])
+        self.assertIn(('mutable_properties', 'john', 'peter'),
+                      results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
 
@@ -43,7 +44,8 @@ class TestProperties(TestCase):
         mapping = {'john': 'jack'}
         results = migrate_properties(portal, mapping, replace=True)
 
-        self.assertIn(('john', 'jack'), results['moved'])
+        self.assertIn(('mutable_properties', 'john', 'jack'),
+                      results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
 
@@ -67,7 +69,8 @@ class TestProperties(TestCase):
         mapping = {'john': 'peter'}
         results = migrate_properties(portal, mapping, mode='copy')
 
-        self.assertIn(('john', 'peter'), results['copied'])
+        self.assertIn(('mutable_properties', 'john', 'peter'),
+                      results['copied'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['deleted'])
 
@@ -82,7 +85,7 @@ class TestProperties(TestCase):
         mapping = {'john': 'peter'}
         results = migrate_properties(portal, mapping, mode='delete')
 
-        self.assertIn(('john', None), results['deleted'])
+        self.assertIn(('mutable_properties', 'john', None), results['deleted'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['moved'])
 

--- a/ftw/usermigration/tests/test_users.py
+++ b/ftw/usermigration/tests/test_users.py
@@ -25,7 +25,7 @@ class TestUsers(TestCase):
         mapping = {'user1': 'john.doe'}
         results = migrate_users(portal, mapping)
 
-        self.assertIn(('user1', 'john.doe'), results['moved'])
+        self.assertIn(('acl_users', 'user1', 'john.doe'), results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
 
@@ -61,7 +61,7 @@ class TestUsers(TestCase):
         portal = self.layer['portal']
         mapping = {'user1': 'jack'}
         results = migrate_users(portal, mapping, replace=True)
-        self.assertIn(('user1', 'jack'), results['moved'])
+        self.assertIn(('acl_users', 'user1', 'jack'), results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
 
@@ -80,7 +80,7 @@ class TestUsers(TestCase):
         mapping = {'user1': 'john.doe'}
         results = migrate_users(portal, mapping, mode='copy')
 
-        self.assertIn(('user1', 'john.doe'), results['copied'])
+        self.assertIn(('acl_users', 'user1', 'john.doe'), results['copied'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['deleted'])
 
@@ -103,7 +103,7 @@ class TestUsers(TestCase):
         mapping = {'user1': 'john.doe'}
         results = migrate_users(portal, mapping, mode='delete')
 
-        self.assertIn(('user1', None), results['deleted'])
+        self.assertIn(('acl_users', 'user1', None), results['deleted'])
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['copied'])
 

--- a/ftw/usermigration/users.py
+++ b/ftw/usermigration/users.py
@@ -45,10 +45,10 @@ def migrate_users(context, mapping, mode='move', replace=False):
                         plugin._userid_to_login[new_userid] = login
 
                     if mode == 'move':
-                        moved.append((old_userid, new_userid))
+                        moved.append(('acl_users', old_userid, new_userid))
                     if mode == 'copy':
-                        copied.append((old_userid, new_userid))
+                        copied.append(('acl_users', old_userid, new_userid))
                     if mode == 'delete':
-                        deleted.append((old_userid, None))
+                        deleted.append(('acl_users', old_userid, None))
 
     return(dict(moved=moved, copied=copied, deleted=deleted))

--- a/ftw/usermigration/utils.py
+++ b/ftw/usermigration/utils.py
@@ -1,0 +1,24 @@
+import errno
+import os
+
+
+def get_buildout_dir():
+    instance_home = os.environ['INSTANCE_HOME']
+    buildout_dir = os.path.sep.join(instance_home.split(os.path.sep)[:-2])
+    return buildout_dir
+
+
+def get_var_log():
+    buildout_dir = get_buildout_dir()
+    var_log = os.path.join(buildout_dir, os.path.join('var', 'log'))
+    return var_log
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise


### PR DESCRIPTION
This PR adds a new option `[ ] Log migration report to file`, that when checked, logs a detailed migration report to a logfile on the server's filesystem (`${buildout}/var/log/usermigration-${timestamp}.log`.

@phgross @deiferni
/cc @buchi 
