### PR TITLE
Add loginnames migration step

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Implement loginnames migration step [elioschmutz]
+
 - Fix migrating users whose username is the beginning of another username [elioschmutz]
 
 - Implement group members migration [elioschmutz]

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -52,7 +52,7 @@
     <h2>Login Names <span tal:replace="mode" /></h2>
     <table class="listing">
         <tr>
-            <th>UserId</th>
+            <th>User ID</th>
             <th>Old Login Name</th>
             <th>New Login Name</th>
         </tr>
@@ -88,9 +88,9 @@
     <h2>Group Members <span tal:replace="mode" /></h2>
     <table class="listing">
         <tr>
-            <th>GroupID</th>
-            <th>Old UserId</th>
-            <th>New UserId</th>
+            <th>Group ID</th>
+            <th>Old User IDs</th>
+            <th>New User ID</th>
         </tr>
         <tr tal:repeat="row rows">
             <td tal:content="python: row[0]" />
@@ -167,8 +167,8 @@
     <table class="listing">
         <tr>
             <th>Column</th>
-            <th>Old UserId</th>
-            <th>New UserId</th>
+            <th>Old User ID</th>
+            <th>New User ID</th>
         </tr>
         <tr tal:repeat="row rows">
             <td tal:content="python: row[0]" />
@@ -186,8 +186,8 @@
     <h2>Homefolders <span tal:replace="mode" /></h2>
     <table class="listing">
         <tr>
-            <th>Old UserId</th>
-            <th>New UserId</th>
+            <th>Old User ID</th>
+            <th>New User ID</th>
         </tr>
         <tr tal:repeat="row rows">
             <td tal:content="python: row[1]" />

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -47,10 +47,10 @@
     </tal:pre-migration-hooks>
 
 
-    <tal:users repeat="mode python:view.results['users'].keys()">
-    <tal:block define="rows python:view.results['users'][mode]"
+    <tal:userids repeat="mode python:view.results['userids'].keys()">
+    <tal:block define="rows python:view.results['userids'][mode]"
                condition="rows">
-    <h2>Users <span tal:replace="mode" /></h2>
+    <h2>Userids <span tal:replace="mode" /></h2>
     <table class="listing">
         <tr>
             <th>Old UserId</th>
@@ -62,7 +62,7 @@
         </tr>
     </table>
     </tal:block>
-    </tal:users>
+    </tal:userids>
 
 
     <tal:group_members repeat="mode python:view.results['group_members'].keys()">

--- a/ftw/usermigration/browser/migration.pt
+++ b/ftw/usermigration/browser/migration.pt
@@ -46,15 +46,33 @@
     </tal:hook_results>
     </tal:pre-migration-hooks>
 
+    <tal:loginnames repeat="mode python:view.results['loginnames'].keys()">
+    <tal:block define="rows python:view.results['loginnames'][mode]"
+               condition="rows">
+    <h2>Login Names <span tal:replace="mode" /></h2>
+    <table class="listing">
+        <tr>
+            <th>UserId</th>
+            <th>Old Login Name</th>
+            <th>New Login Name</th>
+        </tr>
+        <tr tal:repeat="row rows">
+            <td tal:content="python: row[0]" />
+            <td tal:content="python: row[1]" />
+            <td tal:content="python: row[2]" />
+        </tr>
+    </table>
+    </tal:block>
+    </tal:loginnames>
 
     <tal:userids repeat="mode python:view.results['userids'].keys()">
     <tal:block define="rows python:view.results['userids'][mode]"
                condition="rows">
-    <h2>Userids <span tal:replace="mode" /></h2>
+    <h2>User IDs <span tal:replace="mode" /></h2>
     <table class="listing">
         <tr>
-            <th>Old UserId</th>
-            <th>New UserId</th>
+            <th>Old User ID</th>
+            <th>New User ID</th>
         </tr>
         <tr tal:repeat="row rows">
             <td tal:content="python: row[1]" />
@@ -63,7 +81,6 @@
     </table>
     </tal:block>
     </tal:userids>
-
 
     <tal:group_members repeat="mode python:view.results['group_members'].keys()">
     <tal:block define="rows python:view.results['group_members'][mode]"

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -11,7 +11,7 @@ from ftw.usermigration.interfaces import IPreMigrationHook
 from ftw.usermigration.interfaces import IPrincipalMappingSource
 from ftw.usermigration.localroles import migrate_localroles
 from ftw.usermigration.properties import migrate_properties
-from ftw.usermigration.users import migrate_users
+from ftw.usermigration.userids import migrate_userids
 from ftw.usermigration.utils import get_var_log
 from ftw.usermigration.utils import mkdir_p
 from ftw.usermigration.vocabularies import USE_MANUAL_MAPPING
@@ -33,7 +33,7 @@ import transaction
 
 
 BUILTIN_MIGRATIONS = {
-    'users': migrate_users,
+    'userids': migrate_userids,
     'group_members': migrate_group_members,
     'properties': migrate_properties,
     'dashboard': migrate_dashboards,
@@ -86,7 +86,7 @@ class IUserMigrationFormSchema(interface.Interface):
                       'migrations that should be run.'),
         value_type=schema.Choice(
             vocabulary=SimpleVocabulary([
-                SimpleTerm('users', 'users', _(u'Users')),
+                SimpleTerm('userids', 'userids', _(u'Userids')),
                 SimpleTerm('group_members', 'group_members', _(u'Group Members')),
                 SimpleTerm('localroles', 'localroles', _(u'Local Roles')),
                 SimpleTerm('globalroles', 'globalroles', _(u'Global Roles')),

--- a/ftw/usermigration/browser/migration.py
+++ b/ftw/usermigration/browser/migration.py
@@ -10,6 +10,7 @@ from ftw.usermigration.interfaces import IPostMigrationHook
 from ftw.usermigration.interfaces import IPreMigrationHook
 from ftw.usermigration.interfaces import IPrincipalMappingSource
 from ftw.usermigration.localroles import migrate_localroles
+from ftw.usermigration.loginnames import migrate_loginnames
 from ftw.usermigration.properties import migrate_properties
 from ftw.usermigration.userids import migrate_userids
 from ftw.usermigration.utils import get_var_log
@@ -33,6 +34,7 @@ import transaction
 
 
 BUILTIN_MIGRATIONS = {
+    'loginnames': migrate_loginnames,
     'userids': migrate_userids,
     'group_members': migrate_group_members,
     'properties': migrate_properties,
@@ -86,7 +88,8 @@ class IUserMigrationFormSchema(interface.Interface):
                       'migrations that should be run.'),
         value_type=schema.Choice(
             vocabulary=SimpleVocabulary([
-                SimpleTerm('userids', 'userids', _(u'Userids')),
+                SimpleTerm('loginnames', 'loginnames', _(u'Login Names')),
+                SimpleTerm('userids', 'userids', _(u'User IDs')),
                 SimpleTerm('group_members', 'group_members', _(u'Group Members')),
                 SimpleTerm('localroles', 'localroles', _(u'Local Roles')),
                 SimpleTerm('globalroles', 'globalroles', _(u'Global Roles')),

--- a/ftw/usermigration/loginnames.py
+++ b/ftw/usermigration/loginnames.py
@@ -1,0 +1,46 @@
+from Products.CMFCore.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlugin
+from Products.PluggableAuthService.plugins.ZODBUserManager import IZODBUserManager
+
+
+def migrate_loginnames(context, mapping, mode='move', replace=False):
+    """Migrate Plone loginnames.
+    """
+
+    # Statistics
+    moved = []
+    copied = []
+    deleted = []
+
+    uf = getToolByName(context, 'acl_users')
+
+    for old_userid, new_userid in mapping.items():
+        for plugin_id, plugin in uf.plugins.listPlugins(IUserEnumerationPlugin):
+            # Only ZODB User Manager is supported
+            if not IZODBUserManager.providedBy(plugin):
+                continue
+
+            for user in plugin.enumerateUsers(id=old_userid, exact_match=True):
+                current_userid = old_userid
+                old_loginname = plugin._userid_to_login[old_userid]
+                new_loginname = new_userid
+
+                # Do nothing if the new login-id already exists. Replace does not work
+                # here because the login-name is couppled to the userid which will be
+                # migrated in another step.
+                if new_loginname in plugin._login_to_userid:
+                    continue
+
+                if mode not in ['move']:
+                    # This migration step only provides move-mode. All the other
+                    # modes are handled automatically through the userids-migration.
+                    continue
+
+                del plugin._login_to_userid[old_loginname]
+
+                plugin._userid_to_login[current_userid] = new_loginname
+                plugin._login_to_userid[new_loginname] = current_userid
+
+                moved.append((current_userid, old_loginname, new_loginname))
+
+    return(dict(moved=moved, copied=copied, deleted=deleted))

--- a/ftw/usermigration/tests/test_loginnames.py
+++ b/ftw/usermigration/tests/test_loginnames.py
@@ -1,0 +1,162 @@
+from ftw.usermigration.loginnames import migrate_loginnames
+from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from Products.CMFCore.utils import getToolByName
+from unittest2 import TestCase
+
+
+class TestLoginNames(TestCase):
+
+    layer = USERMIGRATION_INTEGRATION_TESTING
+
+    def setUp(self):
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ['Manager'])
+
+        # Create some users
+        mtool = getToolByName(portal, 'portal_membership', None)
+        mtool.addMember('user1', 'password', ['Member'], [])
+        mtool.addMember('jack', 'password', ['Member'], [])
+        mtool.addMember('peter', 'password', ['Member'], [])
+
+        # Change login-name for specific user
+        api.portal.get_tool('acl_users').source_users.updateUser('jack', 'jack@example.ch')
+
+    def test_migrate_loginnames(self):
+        portal = self.layer['portal']
+        mapping = {'user1': 'john.doe'}
+        results = migrate_loginnames(portal, mapping)
+
+        self.assertIn(('user1', 'user1', 'john.doe'), results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+        self.assertEquals(
+            'john.doe',
+            uf.searchUsers(id='user1')[0]['login']
+        )
+
+    def test_migrate_loginnames_which_differs_to_the_userids(self):
+        portal = self.layer['portal']
+        api.portal.get_tool('acl_users').source_users.updateUser('user1', 'hugo.boss@example.ch')
+
+        mapping = {'user1': 'john.doe'}
+        results = migrate_loginnames(portal, mapping)
+
+        self.assertIn(('user1', 'hugo.boss@example.ch', 'john.doe'), results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+        self.assertEquals(
+            'john.doe',
+            uf.searchUsers(id='user1')[0]['login']
+        )
+
+    def test_migrate_to_existing_loginname_without_replace_does_nothing(self):
+        # Change login-name for specific user
+        api.portal.get_tool('acl_users').source_users.updateUser('jack', 'jack@example.ch')
+
+        portal = self.layer['portal']
+        mapping = {'user1': 'jack@example.ch'}
+        results = migrate_loginnames(portal, mapping, replace=False)
+        self.assertEquals([], results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['login']
+        )
+
+    def test_migrate_to_existing_loginname_with_replace_does_nothing(self):
+        # Change login-name for specific user
+        api.portal.get_tool('acl_users').source_users.updateUser('jack', 'jack@example.ch')
+
+        portal = self.layer['portal']
+        mapping = {'user1': 'jack@example.ch'}
+        results = migrate_loginnames(portal, mapping, replace=True)
+        self.assertEquals([], results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['login']
+        )
+
+    def test_migrate_login_to_existing_userid(self):
+        portal = self.layer['portal']
+        api.portal.get_tool('acl_users').source_users.updateUser('jack', 'jack@example.ch')
+
+        mapping = {'user1': 'jack'}
+        results = migrate_loginnames(portal, mapping, replace=True)
+        self.assertIn(('user1', 'user1', 'jack'), results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+        self.assertEquals(
+            'jack',
+            uf.searchUsers(id='user1')[0]['login']
+        )
+
+    def test_copy_loginnames_does_nothing(self):
+        portal = self.layer['portal']
+        mapping = {'user1': 'john.doe'}
+        results = migrate_loginnames(portal, mapping, mode='copy')
+
+        self.assertEquals([], results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['login']
+        )
+
+    def test_delete_loginnames_does_nothing(self):
+        portal = self.layer['portal']
+        mapping = {'user1': 'john.doe'}
+        results = migrate_loginnames(portal, mapping, mode='delete')
+
+        self.assertEquals([], results['deleted'])
+        self.assertEquals([], results['moved'])
+        self.assertEquals([], results['copied'])
+
+        uf = getToolByName(portal, 'acl_users')
+        self.assertEquals(
+            'user1',
+            uf.searchUsers(id='user1')[0]['userid']
+        )
+

--- a/ftw/usermigration/tests/test_migration_form.py
+++ b/ftw/usermigration/tests/test_migration_form.py
@@ -191,6 +191,29 @@ class TestMigrationForm(TestCase):
         # New user's userid is correct
         self.assertEquals('new_john', user['userid'])
 
+        # Login of new user is sill the old one (login migration
+        # is a separate migration step)
+        self.assertEquals('old_john', user['login'])
+
+        # Old user is gone
+        self.assertEquals((), self.uf.searchUsers(id='old_john'))
+
+    @browsing
+    def test_form_user_move_with_loginname(self, browser):
+        browser.login().visit(view='user-migration')
+
+        mapping = make_mapping({'old_john': 'new_john',
+                                'old_jack': 'new_jack'})
+        browser.fill(
+            {'Manual Principal Mapping': mapping,
+             'Migrations': ['loginnames', 'userids']}
+        ).submit()
+
+        user = self.uf.searchUsers(id='new_john')[0]
+
+        # New user's userid is correct
+        self.assertEquals('new_john', user['userid'])
+
         # Login of new user has been set to userid
         self.assertEquals('new_john', user['login'])
 

--- a/ftw/usermigration/tests/test_migration_form.py
+++ b/ftw/usermigration/tests/test_migration_form.py
@@ -69,7 +69,7 @@ class TestMigrationForm(TestCase):
         mapping = make_mapping({'old_john': 'new_john'})
         browser.fill(
             {'Manual Principal Mapping': mapping,
-             'Migrations': ['users']}
+             'Migrations': ['userids']}
         ).submit()
 
         self.assertEquals(1, len(self.uf.searchUsers(id='new_john')))
@@ -91,7 +91,7 @@ class TestMigrationForm(TestCase):
         browser.login().visit(view='user-migration')
 
         browser.fill(
-            {'Migrations': ['users']}
+            {'Migrations': ['userids']}
         ).submit()
 
         self.assertIn(
@@ -109,7 +109,7 @@ class TestMigrationForm(TestCase):
         mapping = make_mapping({'old_john': 'new_john'})
         browser.fill(
             {'Manual Principal Mapping': mapping,
-             'Migrations': ['users', 'properties', 'dashboard',
+             'Migrations': ['userids', 'properties', 'dashboard',
                             'homefolder', 'localroles'],
              'Dry Run': True}
         ).submit()
@@ -131,7 +131,7 @@ class TestMigrationForm(TestCase):
 
         browser.fill(
             {'Principal Mapping Source': 'some-migration-mapping',
-             'Migrations': ['users']}
+             'Migrations': ['userids']}
         ).submit()
 
         self.assertEquals(1, len(self.uf.searchUsers(id='new_john')))
@@ -183,7 +183,7 @@ class TestMigrationForm(TestCase):
                                 'old_jack': 'new_jack'})
         browser.fill(
             {'Manual Principal Mapping': mapping,
-             'Migrations': ['users', 'localroles']}
+             'Migrations': ['userids', 'localroles']}
         ).submit()
 
         user = self.uf.searchUsers(id='new_john')[0]
@@ -205,7 +205,7 @@ class TestMigrationForm(TestCase):
                                 'old_jack': 'new_jack'})
         browser.fill(
             {'Manual Principal Mapping': mapping,
-             'Migrations': ['users', 'localroles'],
+             'Migrations': ['userids', 'localroles'],
              'Mode': 'copy'}
         ).submit()
 

--- a/ftw/usermigration/tests/test_userids.py
+++ b/ftw/usermigration/tests/test_userids.py
@@ -1,5 +1,5 @@
 from ftw.usermigration.testing import USERMIGRATION_INTEGRATION_TESTING
-from ftw.usermigration.users import migrate_users
+from ftw.usermigration.userids import migrate_userids
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -7,7 +7,7 @@ from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
 
 
-class TestUsers(TestCase):
+class TestUserIds(TestCase):
 
     layer = USERMIGRATION_INTEGRATION_TESTING
 
@@ -21,10 +21,10 @@ class TestUsers(TestCase):
         mtool.addMember('jack', 'password', ['Member'], [])
         mtool.addMember('peter', 'password', ['Member'], [])
 
-    def test_migrate_users(self):
+    def test_migrate_userids(self):
         portal = self.layer['portal']
         mapping = {'user1': 'john.doe'}
-        results = migrate_users(portal, mapping)
+        results = migrate_userids(portal, mapping)
 
         self.assertIn(('acl_users', 'user1', 'john.doe'), results['moved'])
         self.assertEquals([], results['copied'])
@@ -47,7 +47,7 @@ class TestUsers(TestCase):
     def test_migrate_to_existing_user_without_replace(self):
         portal = self.layer['portal']
         mapping = {'user1': 'jack'}
-        results = migrate_users(portal, mapping)
+        results = migrate_userids(portal, mapping)
         self.assertEquals([], results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
@@ -61,7 +61,7 @@ class TestUsers(TestCase):
     def test_migrate_to_existing_user_with_replace(self):
         portal = self.layer['portal']
         mapping = {'user1': 'jack'}
-        results = migrate_users(portal, mapping, replace=True)
+        results = migrate_userids(portal, mapping, replace=True)
         self.assertIn(('acl_users', 'user1', 'jack'), results['moved'])
         self.assertEquals([], results['copied'])
         self.assertEquals([], results['deleted'])
@@ -79,7 +79,7 @@ class TestUsers(TestCase):
     def test_copy_users(self):
         portal = self.layer['portal']
         mapping = {'user1': 'john.doe'}
-        results = migrate_users(portal, mapping, mode='copy')
+        results = migrate_userids(portal, mapping, mode='copy')
 
         self.assertIn(('acl_users', 'user1', 'john.doe'), results['copied'])
         self.assertEquals([], results['moved'])
@@ -102,7 +102,7 @@ class TestUsers(TestCase):
     def test_delete_users(self):
         portal = self.layer['portal']
         mapping = {'user1': 'john.doe'}
-        results = migrate_users(portal, mapping, mode='delete')
+        results = migrate_userids(portal, mapping, mode='delete')
 
         self.assertIn(('acl_users', 'user1', None), results['deleted'])
         self.assertEquals([], results['moved'])
@@ -126,7 +126,7 @@ class TestUsers(TestCase):
         mtool.addMember('steven', 'password', ['Member'], [])
 
         mapping = {'steve': 'john.doe'}
-        results = migrate_users(portal, mapping)
+        results = migrate_userids(portal, mapping)
 
         self.assertItemsEqual([('acl_users', 'steve', 'john.doe')], results['moved'])
         self.assertEquals([], results['copied'])

--- a/ftw/usermigration/tests/test_userids.py
+++ b/ftw/usermigration/tests/test_userids.py
@@ -36,7 +36,7 @@ class TestUserIds(TestCase):
             uf.searchUsers(id='john.doe')[0]['userid']
         )
         self.assertEquals(
-            'john.doe',
+            'user1',
             uf.searchUsers(id='john.doe')[0]['login']
         )
         self.assertEquals(

--- a/ftw/usermigration/userids.py
+++ b/ftw/usermigration/userids.py
@@ -34,9 +34,10 @@ def migrate_userids(context, mapping, mode='move', replace=False):
                     del plugin._login_to_userid[login]
 
                 if mode in ['copy', 'move']:
-                    # If userid and login are the same or if in copy mode,
-                    # set login to new userid.
-                    if login == old_userid or mode == 'copy':
+                    # We set the login-name to the new userid on user-copy.
+                    # We do this because we don't want two users with the same
+                    # loginname.
+                    if mode == 'copy':
                         login = new_userid
 
                     plugin._user_passwords[new_userid] = pw

--- a/ftw/usermigration/userids.py
+++ b/ftw/usermigration/userids.py
@@ -3,8 +3,8 @@ from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlu
 from Products.PluggableAuthService.plugins.ZODBUserManager import IZODBUserManager
 
 
-def migrate_users(context, mapping, mode='move', replace=False):
-    """Migrate Plone users."""
+def migrate_userids(context, mapping, mode='move', replace=False):
+    """Migrate Plone userids."""
 
     # Statistics
     moved = []


### PR DESCRIPTION
This PR implements a separate loginname migration step.

![screen1](https://cloud.githubusercontent.com/assets/557005/24911980/0ff329f4-1ecd-11e7-9b16-c58ebe0c5255.gif)

closes #12 